### PR TITLE
Unneded output processor in calibration chain

### DIFF
--- a/calibration/PandoraEMScaleStep.py
+++ b/calibration/PandoraEMScaleStep.py
@@ -20,6 +20,8 @@ class PandoraEMScaleStep(CalibrationStep) :
         self._maxNIterations = 5
         self._energyScaleAccuracy = 0.01
         self._photonEnergy = 0
+        self._recProcessorName = ""
+        self._dstProcessorName = ""
 
         # step input
         self._inputEcalToEMGeV = None
@@ -38,6 +40,10 @@ class PandoraEMScaleStep(CalibrationStep) :
 
     def description(self):
         return "Calibrate the electromagnetic scale of the ecal and the hcal. Outputs the constants ECalToEMGeVCalibration and HCalToEMGeVCalibration"
+
+    def setOutputProcessorNames(self, recProcessor, dstProcessor):
+        self._recProcessorName = recProcessor
+        self._dstProcessorName = dstProcessor
 
     def readCmdLine(self, parsed) :
         # setup marlin
@@ -67,6 +73,12 @@ class PandoraEMScaleStep(CalibrationStep) :
         
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
+        
+        if len(self._recProcessorName):
+            self._marlin.turnOffProcessors([self._recProcessorName])
+            
+        if len(self._dstProcessorName):
+            self._marlin.turnOffProcessors([self._dstProcessorName])
 
         self._inputEcalToEMGeV = float(self._marlin.getProcessorParameter(self._marlinPandoraProcessor, "ECalToEMGeVCalibration"))
         self._inputHcalToEMGeV = float(self._marlin.getProcessorParameter(self._marlinPandoraProcessor, "HCalToEMGeVCalibration"))

--- a/calibration/PandoraHadScaleStep.py
+++ b/calibration/PandoraHadScaleStep.py
@@ -22,6 +22,8 @@ class PandoraHadScaleStep(CalibrationStep) :
         self._ecalEnergyScaleAccuracy = 0.01
         self._hcalEnergyScaleAccuracy = 0.01
         self._kaon0LEnergy = 0
+        self._recProcessorName = ""
+        self._dstProcessorName = ""
 
         # step input
         self._inputEcalToHadGeVBarrel = None
@@ -44,6 +46,10 @@ class PandoraHadScaleStep(CalibrationStep) :
     def description(self):
         return "Calibrate the hadronic scale of the ecal and the hcal. Outputs the constants ECalToHadGeVCalibrationBarrel, ECalToHadGeVCalibrationEndCap and HCalToHadGeVCalibration"
 
+    def setOutputProcessorNames(self, recProcessor, dstProcessor):
+        self._recProcessorName = recProcessor
+        self._dstProcessorName = dstProcessor
+        
     def readCmdLine(self, parsed) :
         # setup marlin
         self._marlin = Marlin(parsed.steeringFile)
@@ -73,6 +79,12 @@ class PandoraHadScaleStep(CalibrationStep) :
         
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
+            
+        if len(self._recProcessorName):
+            self._marlin.turnOffProcessors([self._recProcessorName])
+            
+        if len(self._dstProcessorName):
+            self._marlin.turnOffProcessors([self._dstProcessorName])
 
     def run(self, config) :
         # loop variables

--- a/scripts/run-ild-calibration.py
+++ b/scripts/run-ild-calibration.py
@@ -25,6 +25,8 @@ if __name__ == "__main__":
     gearConversionPlugin = "default"
     pandoraProcessor = "MyDDMarlinPandora"
     pfoAnalysisProcessor = "MyPfoAnalysis"
+    recOutputProcessor = "MyLCIOOutputProcessor"
+    dstOutputProcessor = "DSTOutput"
     runEcalRingCalibration = True
     runHcalRingCalibration = True
     stepNames = []
@@ -131,6 +133,7 @@ if __name__ == "__main__":
     stepNames.append(pandoraEMScaleStep.name())
     pandoraEMScaleStep.setPfoAnalysisProcessor(pfoAnalysisProcessor)
     pandoraEMScaleStep.setMarlinPandoraProcessor(pandoraProcessor)
+    pandoraEMScaleStep.setOutputProcessorNames(recOutputProcessor, dstOutputProcessor)
     manager.addStep( pandoraEMScaleStep )
 
     # Pandora hadronic scale calibration
@@ -139,6 +142,7 @@ if __name__ == "__main__":
     stepNames.append(pandoraHadScaleStep.name())
     pandoraHadScaleStep.setPfoAnalysisProcessor(pfoAnalysisProcessor)
     pandoraHadScaleStep.setMarlinPandoraProcessor(pandoraProcessor)
+    pandoraHadScaleStep.setOutputProcessorNames(recOutputProcessor, dstOutputProcessor)
     manager.addStep( pandoraHadScaleStep )
 
     pandoraSoftCompStep = PandoraSoftCompStep()


### PR DESCRIPTION
BEGINRELEASENOTES
- Added option in Pandora steps (EM and Had scale) to remove the execution of REC and DST files
- Set MyLCIOOutputProcessor and DSTOutput processor to be removed for the ILD calibration

ENDRELEASENOTES