### PR TITLE
ILD calibration: Turn off REC and DST processors

### DIFF
--- a/calibration/CalibrationStep.py
+++ b/calibration/CalibrationStep.py
@@ -59,7 +59,7 @@ class CalibrationStep(object) :
     """ Set the processor list to turn off
     """
     def setTurnoffProcessors(self, processors):
-        self._turnOffProcessors = list(processors)
+        self._turnoffProcessors = list(processors)
     
     def setMarlinPandoraProcessor(self, processor):
         self._marlinPandoraProcessor = str(processor)

--- a/calibration/CalibrationStep.py
+++ b/calibration/CalibrationStep.py
@@ -15,6 +15,7 @@ class CalibrationStep(object) :
         self._pfoAnalysisProcessor =  "MyPfoAnalysis"
         self._marlinPandoraProcessor = "MyDDMarlinPandora"
         self._runProcessors = list()
+        self._turnoffProcessors = list()
 
     def setManager(self, mgr) :
         self._manager = mgr
@@ -54,6 +55,11 @@ class CalibrationStep(object) :
     """
     def setRunProcessors(self, processors):
         self._runProcessors = list(processors)
+
+    """ Set the processor list to turn off
+    """
+    def setTurnoffProcessors(self, processors):
+        self._turnOffProcessors = list(processors)
     
     def setMarlinPandoraProcessor(self, processor):
         self._marlinPandoraProcessor = str(processor)

--- a/calibration/EcalEnergyStep.py
+++ b/calibration/EcalEnergyStep.py
@@ -91,6 +91,10 @@ class EcalEnergyStep(CalibrationStep) :
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
 
+        if len(self._turnoffProcessors):
+            self._marlin.turnOffProcessors(self._turnoffProcessors)
+        
+
     """ Run the calibration step
     """
     def run(self, config) :

--- a/calibration/HcalEnergyStep.py
+++ b/calibration/HcalEnergyStep.py
@@ -98,6 +98,9 @@ class HcalEnergyStep(CalibrationStep) :
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
 
+        if len(self._turnoffProcessors):
+            self._marlin.turnOffProcessors(self._turnoffProcessors)
+
 
     def run(self, config) :
 

--- a/calibration/MipScaleStep.py
+++ b/calibration/MipScaleStep.py
@@ -61,6 +61,9 @@ class MipScaleStep(CalibrationStep) :
                 
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
+
+        if len(self._turnoffProcessors):
+            self._marlin.turnOffProcessors(self._turnoffProcessors)
             
         self._marlin.run()
 

--- a/calibration/PandoraEMScaleStep.py
+++ b/calibration/PandoraEMScaleStep.py
@@ -20,8 +20,6 @@ class PandoraEMScaleStep(CalibrationStep) :
         self._maxNIterations = 5
         self._energyScaleAccuracy = 0.01
         self._photonEnergy = 0
-        self._recProcessorName = ""
-        self._dstProcessorName = ""
 
         # step input
         self._inputEcalToEMGeV = None
@@ -41,10 +39,6 @@ class PandoraEMScaleStep(CalibrationStep) :
 
     def description(self):
         return "Calibrate the electromagnetic scale of the ecal and the hcal. Outputs the constants ECalToEMGeVCalibration and HCalToEMGeVCalibration"
-
-    def setOutputProcessorNames(self, recProcessor, dstProcessor):
-        self._recProcessorName = recProcessor
-        self._dstProcessorName = dstProcessor
 
     def readCmdLine(self, parsed) :
         # setup marlin
@@ -74,12 +68,9 @@ class PandoraEMScaleStep(CalibrationStep) :
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
         
-        if len(self._recProcessorName):
-            self._marlin.turnOffProcessors([self._recProcessorName])
+        if len(self._turnoffProcessors):
+            self._marlin.turnOffProcessors(self._turnoffProcessors)
             
-        if len(self._dstProcessorName):
-            self._marlin.turnOffProcessors([self._dstProcessorName])
-
         self._inputEcalToEMGeV = float(self._marlin.getProcessorParameter(self._marlinPandoraProcessor, "ECalToEMGeVCalibration"))
         self._inputHcalToEMGeV = float(self._marlin.getProcessorParameter(self._marlinPandoraProcessor, "HCalToEMGeVCalibration"))
 

--- a/calibration/PandoraHadScaleStep.py
+++ b/calibration/PandoraHadScaleStep.py
@@ -22,8 +22,6 @@ class PandoraHadScaleStep(CalibrationStep) :
         self._ecalEnergyScaleAccuracy = 0.01
         self._hcalEnergyScaleAccuracy = 0.01
         self._kaon0LEnergy = 0
-        self._recProcessorName = ""
-        self._dstProcessorName = ""
 
         # step input
         self._inputEcalToHadGeVBarrel = None
@@ -47,10 +45,6 @@ class PandoraHadScaleStep(CalibrationStep) :
     def description(self):
         return "Calibrate the hadronic scale of the ecal and the hcal. Outputs the constants ECalToHadGeVCalibrationBarrel, ECalToHadGeVCalibrationEndCap and HCalToHadGeVCalibration"
 
-    def setOutputProcessorNames(self, recProcessor, dstProcessor):
-        self._recProcessorName = recProcessor
-        self._dstProcessorName = dstProcessor
-        
     def readCmdLine(self, parsed) :
         # setup marlin
         self._marlin = Marlin(parsed.steeringFile)
@@ -79,13 +73,10 @@ class PandoraHadScaleStep(CalibrationStep) :
         
         if len(self._runProcessors):
             self._marlin.turnOffProcessorsExcept(self._runProcessors)
-            
-        if len(self._recProcessorName):
-            self._marlin.turnOffProcessors([self._recProcessorName])
-            
-        if len(self._dstProcessorName):
-            self._marlin.turnOffProcessors([self._dstProcessorName])
 
+        if len(self._turnoffProcessors):
+            self._marlin.turnOffProcessors(self._turnoffProcessors)
+            
     def run(self, config) :
         # loop variables
         currentEcalPrecision = 0.

--- a/calibration/PandoraSoftCompStep.py
+++ b/calibration/PandoraSoftCompStep.py
@@ -87,6 +87,9 @@ class PandoraSoftCompStep(CalibrationStep) :
                 marlin.setMaxRecordNumber(parsed.maxRecordNumber)
                 marlin.setProcessorParameter(self._marlinPandoraProcessor, "PandoraSettingsXmlFile", str(newPandoraXmlFileName))
 
+                if len(self._turnoffProcessors):
+                    marlin.turnOffProcessors(self._turnoffProcessors)
+
                 try:
                     marlin.setProcessorParameter(self._pfoAnalysisProcessor, "RootFile", str(pfoAnalysisFile))
                 except:

--- a/scripts/run-ild-calibration.py
+++ b/scripts/run-ild-calibration.py
@@ -25,8 +25,7 @@ if __name__ == "__main__":
     gearConversionPlugin = "default"
     pandoraProcessor = "MyDDMarlinPandora"
     pfoAnalysisProcessor = "MyPfoAnalysis"
-    recOutputProcessor = "MyLCIOOutputProcessor"
-    dstOutputProcessor = "DSTOutput"
+    turnoffProcessors = ["MyLCIOOutputProcessor", "DSTOutput"]
     runEcalRingCalibration = True
     runHcalRingCalibration = True
     stepNames = []
@@ -133,7 +132,7 @@ if __name__ == "__main__":
     stepNames.append(pandoraEMScaleStep.name())
     pandoraEMScaleStep.setPfoAnalysisProcessor(pfoAnalysisProcessor)
     pandoraEMScaleStep.setMarlinPandoraProcessor(pandoraProcessor)
-    pandoraEMScaleStep.setOutputProcessorNames(recOutputProcessor, dstOutputProcessor)
+    pandoraEMScaleStep.setTurnoffProcessors(turnoffProcessors)
     manager.addStep( pandoraEMScaleStep )
 
     # Pandora hadronic scale calibration
@@ -142,7 +141,7 @@ if __name__ == "__main__":
     stepNames.append(pandoraHadScaleStep.name())
     pandoraHadScaleStep.setPfoAnalysisProcessor(pfoAnalysisProcessor)
     pandoraHadScaleStep.setMarlinPandoraProcessor(pandoraProcessor)
-    pandoraHadScaleStep.setOutputProcessorNames(recOutputProcessor, dstOutputProcessor)
+    pandoraHadScaleStep.setTurnoffProcessors(turnoffProcessors)
     manager.addStep( pandoraHadScaleStep )
 
     pandoraSoftCompStep = PandoraSoftCompStep()
@@ -150,6 +149,7 @@ if __name__ == "__main__":
     stepNames.append(pandoraHadScaleStep.name())
     pandoraSoftCompStep.setPfoAnalysisProcessor(pfoAnalysisProcessor)
     pandoraSoftCompStep.setMarlinPandoraProcessor(pandoraProcessor)
+    pandoraSoftCompStep.setTurnoffProcessors(turnoffProcessors)
     manager.addStep( pandoraSoftCompStep )
 
     manager.run()


### PR DESCRIPTION
BEGINRELEASENOTES
- CalibrationStep:
  - Added setter to specify processors to turnoff
- All calibration steps turn off specified list of processors if any
- ILD calibration runner: 
  - Removed REC and DST processors setter for Pandora step (superseded by CalibrationStep new method)
  - Turn off REC and DST processors in all calibration steps to avoid un-necessary disk space usage

ENDRELEASENOTES